### PR TITLE
Update slack-export-viewer to 1.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-slack-export-viewer==0.9.0
+slack-export-viewer==1.1.4
 frozen-flask
 click
 flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-slack-export-viewer==1.1.4
+slack-export-viewer
 frozen-flask
 click
 flask


### PR DESCRIPTION
Fix `KeyError: 'replies'` and `emojize for emoji>=2.0.0`.

I didn't see any compatibility issues as noted in #3. Maybe it's worth just unpinning it at this point.